### PR TITLE
correct link to a video

### DIFF
--- a/templates/showMovie.html
+++ b/templates/showMovie.html
@@ -23,6 +23,6 @@ Netflix - Movie
         
         const video_param = parseInt(url.searchParams.get("epi")) ? parseInt(url.searchParams.get("epi")) : 0
 
-        videoEl.setAttribute('src',`http:/localhost:8000/media/${movie_data[video_param].file}`)
+        videoEl.setAttribute('src',`http://localhost:8000/media/${movie_data[video_param].file}`)
     </script>
 {% endblock content %}


### PR DESCRIPTION
Fixes #1 

I watched your video course and the video did not play for me either. The problem was solved simply, you just had to add one `/`

Thank you @Swati-13 for your comment!

And yes, you typed correctly in the video: https://youtu.be/gbyYXgiSgdM?t=13311